### PR TITLE
chore: revert unforked `react-currency-input-field`

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "jw-paginate": "^1.0.4",
     "lodash": "^4.17.20",
     "polished": "^3.6.5",
-    "react-currency-input-field": "https://github.com/dziraf/react-currency-input-field",
+    "react-currency-input-field": "^3.6.5",
     "react-datepicker": "^4.8.0",
     "react-phone-input-2": "^2.15.1",
     "react-select": "^5.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6157,9 +6157,10 @@ rc@1.2.8, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-currency-input-field@https://github.com/dziraf/react-currency-input-field.git":
-  version "3.6.4"
-  resolved "git+ssh://git@github.com/dziraf/react-currency-input-field.git#6ee883672ecee131b1503d48319a50aa64fdcd26"
+react-currency-input-field@^3.6.5:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/react-currency-input-field/-/react-currency-input-field-3.6.5.tgz#67ed7005a2f1402cb70a23050f6b997e6d1452b6"
+  integrity sha512-tP62WFAhkVv0RGOQVGEPE3MfgciQ4gkiASlmLBDu6tdfMC3jFhIkLU1uqUy3glUvRHyT4avnX/YVVbbXKHLtnA==
 
 react-datepicker@^4.8.0:
   version "4.8.0"


### PR DESCRIPTION
As of [v3.6.5][1], the upstream, unforked `react-currency-input-field` [supports React 18][2].

[1]: https://github.com/cchanxzy/react-currency-input-field/releases/tag/v3.6.5
[2]: https://github.com/cchanxzy/react-currency-input-field/issues/230