### PR TITLE
fix err_package_not_exported error in typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     },
     "./styled-components": {
       "import": "./build/utils/styled.js",
-      "types": "./types/src/utils/styled.d.ts"
+      "types": "./types/src/utils/styled.d.ts",
+      "require": "./build/utils/styled.js"
     }
   },
   "repository": "git@github.com:SoftwareBrothers/adminjs-design-system.git",


### PR DESCRIPTION
 Fix `ERR_PACKAGE_PATH_NOT_EXPORTED` when building project in typescript